### PR TITLE
Ability to override dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Installs and caches all packages defined in the project directory's `package.jso
 
  * `options` - An object with various settings. All options are _optional_.
 
+   * `dependencies` (object) - override the dependencies from package.json.
    * `allowShrinkwrap` (boolean) - When true, tells npm to honor shrinkwrap settings. Defaults to `false`.
    * `cacheDir` (string) - The directory to cache modules. Defaults to `~/.npm-fast-install`.
    * `dir` (string) - The directory containing the package.json. Defaults to `process.cwd()`.

--- a/index.js
+++ b/index.js
@@ -60,17 +60,28 @@ function install(opts) {
 		logger.info('Module version:  %s', modulesAPI);
 		logger.info('npm version:     %s', npm.version + '\n');
 
-		// load the package.json
-		var pkgJsonFile = path.join(dir, 'package.json');
-		if (!fs.existsSync(pkgJsonFile)) {
-			return reject(new Error('No package.json found'));
+		var deps = [];
+		
+		if (opts.dependencies) {
+			deps = Object.keys(opts.dependencies).map(function (dep) {
+				return { name: dep, ver: opts.dependencies[dep] };
+			});
+		} else {
+			// load the package.json
+			var pkgJsonFile = path.join(dir, 'package.json');
+			if (!opts.dependencies) {
+				if (!fs.existsSync(pkgJsonFile)) {
+					return reject(new Error('No package.json found'));
+				}
+				logger.info('Loading package.json: %s', pkgJsonFile);
+			}
+			var pkgJson = require(pkgJsonFile);
+			if (pkgJson.dependencies && typeof pkgJson.dependencies === 'object') {
+				deps = Object.keys(pkgJson.dependencies).map(function (dep) {
+					return { name: dep, ver: pkgJson.dependencies[dep] };
+				});
+			}
 		}
-		logger.info('Loading package.json: %s', pkgJsonFile);
-
-		var pkgJson = require(pkgJsonFile);
-		var deps = pkgJson.dependencies && typeof pkgJson.dependencies === 'object' ? Object.keys(pkgJson.dependencies).map(function (dep) {
-			return { name: dep, ver: pkgJson.dependencies[dep] };
-		}) : [];
 		var results = {
 			node: process.version,
 			arch: process.arch,


### PR DESCRIPTION
This introduces the `dependencies` option, allowing the API user to override the `dependencies` field in `package.json`.

In essence this allows `npm-fast-install` to be used to install arbitrary modules at runtime.
